### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG COREVERSION="latest"
 
-FROM golang:1.24-alpine as build
+FROM golang:1.26-bookworm AS build
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -9,29 +9,32 @@ RUN go mod download
 COPY . ./
 
 # to get buildinfo in golang
-RUN apk add git
+RUN apt-get update && apt-get -y install git && rm -rf /var/lib/apt/lists/*
 ARG VERSION="dev"
 RUN go build -v -ldflags "-X main.version=${VERSION}" ./cmd/fireantelope
 
 ####
 
-FROM ghcr.io/streamingfast/firehose-core:${COREVERSION} as core
+FROM ghcr.io/streamingfast/firehose-core:${COREVERSION} AS core
 
 ####
 
-FROM alpine:3
+FROM ubuntu:24.04
 
-ENV PATH "$PATH:/app"
+ARG TARGETARCH
+
+ENV PATH="$PATH:/app"
 
 #COPY tools/fireeth/motd_generic /etc/motd
 #COPY tools/fireeth/99-fireeth.sh /etc/profile.d/
 #RUN echo ". /etc/profile.d/99-fireeth.sh" > /root/.bash_aliases
 
-RUN apk --no-cache add \
+RUN apt-get update && apt-get -y upgrade && apt-get -y install \
         ca-certificates htop iotop sysstat \
-        strace lsof curl jq tzdata bash
+        strace lsof curl jq tzdata bash \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /app/ && curl -Lo /app/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.12/grpc_health_probe-linux-amd64 && chmod +x /app/grpc_health_probe
+RUN mkdir -p /app/ && curl -Lo /app/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.12/grpc_health_probe-linux-${TARGETARCH} && chmod +x /app/grpc_health_probe
 
 WORKDIR /app
 


### PR DESCRIPTION
The docker build has been failing since the Go version in `go.mod` moved past the `golang:1.24-alpine` pin in the Dockerfile.

Fixing that surfaced a second issue: substreams pulls in `wasmtime-go`, which is cgo, and `golang:alpine` has no C toolchain — so cgo gets disabled and the symbols go undefined. Same story at runtime, where the `firecore` binary we copy in is glibc-linked and cannot run on alpine.

Switched both stages to match the upstream firehose-core Dockerfile: `golang:1.26-bookworm` to build, `ubuntu:24.04` at runtime. Also derives the `grpc_health_probe` arch from `TARGETARCH` instead of hardcoding amd64.

Verified with a full local build — `fireantelope`, `firecore`, and `grpc_health_probe` all run in the final image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)